### PR TITLE
[Feat] OnO 2.0.0 버전 백엔드 서버 배포

### DIFF
--- a/src/main/java/com/aisip/OnO/backend/Dto/Problem/ProblemRegisterDtoV2.java
+++ b/src/main/java/com/aisip/OnO/backend/Dto/Problem/ProblemRegisterDtoV2.java
@@ -1,0 +1,37 @@
+package com.aisip.OnO.backend.Dto.Problem;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProblemRegisterDtoV2 {
+
+    private Long problemId;
+
+    private String problemImageUrl;
+
+    private String processImageUrl;
+
+    private MultipartFile answerImage;
+
+    private MultipartFile solveImage;
+
+    private String memo;
+
+    private String reference;
+
+    private Long folderId;
+
+    private Long templateType;
+
+    private String analysis;
+
+    private LocalDateTime solvedAt;
+}
+

--- a/src/main/java/com/aisip/OnO/backend/Dto/Problem/ProblemRepeatDto.java
+++ b/src/main/java/com/aisip/OnO/backend/Dto/Problem/ProblemRepeatDto.java
@@ -1,0 +1,15 @@
+package com.aisip.OnO.backend.Dto.Problem;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProblemRepeatDto {
+    private Long id;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/aisip/OnO/backend/Dto/Problem/ProblemResponseDto.java
+++ b/src/main/java/com/aisip/OnO/backend/Dto/Problem/ProblemResponseDto.java
@@ -1,11 +1,13 @@
 package com.aisip.OnO.backend.Dto.Problem;
 
+import com.aisip.OnO.backend.entity.Problem.ProblemRepeat;
 import com.aisip.OnO.backend.entity.Problem.TemplateType;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 @Builder
@@ -25,12 +27,16 @@ public class ProblemResponseDto {
 
     private String memo;
 
+    private Long folderId;
+
     private String reference;
 
     private String analysis;
 
+    private List<ProblemRepeatDto> repeats;
+
     @Enumerated(EnumType.STRING)
-    private TemplateType templateType;
+    private Long templateType;
 
     private LocalDateTime solvedAt;
 
@@ -38,3 +44,4 @@ public class ProblemResponseDto {
 
     private LocalDateTime updateAt;
 }
+

--- a/src/main/java/com/aisip/OnO/backend/controller/ImageProcessController.java
+++ b/src/main/java/com/aisip/OnO/backend/controller/ImageProcessController.java
@@ -47,12 +47,13 @@ public class ImageProcessController {
         }
     }
 
-    @GetMapping("/analysis")
+    @PostMapping("/analysis")
     public ResponseEntity<?> getProblemAnalysis(
             Authentication authentication,
-            @RequestParam("problemImageUrl") String problemImageUrl
+            @RequestBody Map<String, String> requestBody
     ) {
         try {
+            String problemImageUrl = requestBody.get("problemImageUrl");
             String analysisResult = fileUploadService.getProblemAnalysis(problemImageUrl);
 
             return ResponseEntity.ok(Map.of("analysis", analysisResult));
@@ -63,10 +64,10 @@ public class ImageProcessController {
         }
     }
 
-    @GetMapping("/processImage")
+    @PostMapping("/processImage")
     public ResponseEntity<?> getProcessImage(
             Authentication authentication,
-            @ModelAttribute ImageProcessRegisterDto imageProcessRegisterDto
+            @RequestBody ImageProcessRegisterDto imageProcessRegisterDto
             ) {
         try {
             String processImageUrl = fileUploadService.getProcessImageUrl(imageProcessRegisterDto);

--- a/src/main/java/com/aisip/OnO/backend/controller/ProblemController.java
+++ b/src/main/java/com/aisip/OnO/backend/controller/ProblemController.java
@@ -1,6 +1,7 @@
 package com.aisip.OnO.backend.controller;
 
 import com.aisip.OnO.backend.Dto.Problem.ProblemRegisterDto;
+import com.aisip.OnO.backend.Dto.Problem.ProblemRegisterDtoV2;
 import com.aisip.OnO.backend.Dto.Problem.ProblemResponseDto;
 import com.aisip.OnO.backend.exception.ProblemNotFoundException;
 import com.aisip.OnO.backend.exception.ProblemRegisterException;
@@ -71,6 +72,31 @@ public class ProblemController {
         try {
             Long userId = (Long) authentication.getPrincipal();
             boolean isSaved = problemService.saveProblem(userId, problemRegisterDto);
+
+            if (isSaved) {
+                log.info("userId: " + userId + " success for register problem");
+                return ResponseEntity.ok().body("문제가 등록되었습니다.");
+            } else {
+                throw new ProblemRegisterException("userId: " + userId + " failed for register problem");
+            }
+
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            Sentry.captureException(e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                    "Error Register Problem: " + e.getMessage()
+            );
+        }
+    }
+
+    @PostMapping("/problem/V2")
+    public ResponseEntity<?> registerProblemV2(
+            Authentication authentication,
+            @ModelAttribute ProblemRegisterDtoV2 problemRegisterDto
+    ) {
+        try {
+            Long userId = (Long) authentication.getPrincipal();
+            boolean isSaved = problemService.saveProblemV2(userId, problemRegisterDto);
 
             if (isSaved) {
                 log.info("userId: " + userId + " success for register problem");

--- a/src/main/java/com/aisip/OnO/backend/controller/ProblemController.java
+++ b/src/main/java/com/aisip/OnO/backend/controller/ProblemController.java
@@ -157,4 +157,23 @@ public class ProblemController {
                     .body(e.getMessage());
         }
     }
+
+    @PostMapping("/problem/repeat")
+    public ResponseEntity<?> addRepeatCount(
+            Authentication authentication,
+            @RequestHeader("problemId") Long problemId
+    ){
+        try{
+            Long userId = (Long) authentication.getPrincipal();
+            problemService.addRepeatCount(problemId);
+
+            log.info("userId: " + userId + " repeat problemId : " + problemId);
+            return ResponseEntity.ok("삭제를 완료했습니다.");
+        } catch (Exception e) {
+            log.warn(e.getMessage());
+            Sentry.captureException(e);
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(e.getMessage());
+        }
+    }
 }

--- a/src/main/java/com/aisip/OnO/backend/converter/ProblemConverter.java
+++ b/src/main/java/com/aisip/OnO/backend/converter/ProblemConverter.java
@@ -5,6 +5,7 @@ import com.aisip.OnO.backend.Dto.Problem.ProblemResponseDto;
 import com.aisip.OnO.backend.entity.Image.ImageData;
 import com.aisip.OnO.backend.entity.Problem.Problem;
 import com.aisip.OnO.backend.entity.Problem.ProblemRepeat;
+import com.aisip.OnO.backend.entity.Problem.TemplateType;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -31,7 +32,7 @@ public class ProblemConverter {
                             .updatedAt(problemRepeat.getUpdatedAt())
                             .build()
                 ).collect(Collectors.toList()))
-                .templateType(problem.getTemplateType().getCode())
+                .templateType(problem.getTemplateType() != null ? problem.getTemplateType().getCode() : TemplateType.SIMPLE_TEMPLATE.getCode())
                 .build();
 
         for (ImageData image : images) {

--- a/src/main/java/com/aisip/OnO/backend/converter/ProblemConverter.java
+++ b/src/main/java/com/aisip/OnO/backend/converter/ProblemConverter.java
@@ -1,14 +1,17 @@
 package com.aisip.OnO.backend.converter;
 
+import com.aisip.OnO.backend.Dto.Problem.ProblemRepeatDto;
 import com.aisip.OnO.backend.Dto.Problem.ProblemResponseDto;
 import com.aisip.OnO.backend.entity.Image.ImageData;
 import com.aisip.OnO.backend.entity.Problem.Problem;
+import com.aisip.OnO.backend.entity.Problem.ProblemRepeat;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class ProblemConverter {
 
-    public static ProblemResponseDto convertToResponseDto(Problem problem, List<ImageData> images) {
+    public static ProblemResponseDto convertToResponseDto(Problem problem, List<ImageData> images, List<ProblemRepeat> repeats) {
         if (problem == null) {
             return null;
         }
@@ -20,8 +23,15 @@ public class ProblemConverter {
                 .solvedAt(problem.getSolvedAt())
                 .createdAt(problem.getCreatedAt())
                 .updateAt(problem.getUpdatedAt())
+                .folderId(problem.getFolder().getId())
                 .analysis(problem.getAnalysis())
-                .templateType(problem.getTemplateType())
+                .repeats(repeats.stream().map(problemRepeat -> ProblemRepeatDto.builder()
+                            .id(problemRepeat.getId())
+                            .createdAt(problemRepeat.getCreatedAt())
+                            .updatedAt(problemRepeat.getUpdatedAt())
+                            .build()
+                ).collect(Collectors.toList()))
+                .templateType(problem.getTemplateType().getCode())
                 .build();
 
         for (ImageData image : images) {

--- a/src/main/java/com/aisip/OnO/backend/entity/Problem/Problem.java
+++ b/src/main/java/com/aisip/OnO/backend/entity/Problem/Problem.java
@@ -37,6 +37,7 @@ public class Problem extends BaseEntity {
 
     private LocalDateTime solvedAt;
 
+    @Column(columnDefinition = "LONGTEXT")
     private String analysis;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/aisip/OnO/backend/entity/Problem/ProblemRepeat.java
+++ b/src/main/java/com/aisip/OnO/backend/entity/Problem/ProblemRepeat.java
@@ -1,0 +1,23 @@
+package com.aisip.OnO.backend.entity.Problem;
+
+import com.aisip.OnO.backend.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "problem_repeat")
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ProblemRepeat extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch =  FetchType.LAZY)
+    @JoinColumn(name = "problem_id")
+    private Problem problem;
+}

--- a/src/main/java/com/aisip/OnO/backend/entity/Problem/TemplateType.java
+++ b/src/main/java/com/aisip/OnO/backend/entity/Problem/TemplateType.java
@@ -2,19 +2,19 @@ package com.aisip.OnO.backend.entity.Problem;
 
 public enum TemplateType {
 
-    SIMPLE_TEMPLATE(1, "simple template"),
-    CLEAN_TEMPLATE(2, "clean template"),
-    SPECIAL_TEMPLATE(3, "special template");
+    SIMPLE_TEMPLATE(1L, "simple template"),
+    CLEAN_TEMPLATE(2L, "clean template"),
+    SPECIAL_TEMPLATE(3L, "special template");
 
-    private final int code;
+    private final Long code;
     private final String description;
 
-    TemplateType(int code, String description) {
+    TemplateType(Long code, String description) {
         this.code = code;
         this.description = description;
     }
 
-    public int getCode() {
+    public Long getCode() {
         return code;
     }
 
@@ -22,9 +22,9 @@ public enum TemplateType {
         return description;
     }
 
-    public static TemplateType valueOf(int code) {
+    public static TemplateType valueOf(Long code) {
         for (TemplateType type : values()) {
-            if (type.getCode() == code) {
+            if (type.getCode().equals(code)) {
                 return type;
             }
         }

--- a/src/main/java/com/aisip/OnO/backend/repository/ImageDataRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/repository/ImageDataRepository.java
@@ -10,5 +10,6 @@ import java.util.Optional;
 public interface ImageDataRepository extends JpaRepository<ImageData, Long> {
     List<ImageData> findByProblemId(Long problemId);
 
+    Optional<ImageData> findByImageUrl(String imageUrl);
     Optional<ImageData> findByProblemIdAndImageType(Long problemId, ImageType imageType);
 }

--- a/src/main/java/com/aisip/OnO/backend/repository/ProblemRepeatRepository.java
+++ b/src/main/java/com/aisip/OnO/backend/repository/ProblemRepeatRepository.java
@@ -1,0 +1,12 @@
+package com.aisip.OnO.backend.repository;
+
+import com.aisip.OnO.backend.entity.Problem.ProblemRepeat;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ProblemRepeatRepository extends JpaRepository<ProblemRepeat, Long> {
+    Long countByProblemId(Long problemId);
+
+    List<ProblemRepeat> findAllByProblemId(Long problemId);
+}

--- a/src/main/java/com/aisip/OnO/backend/service/FileUploadService.java
+++ b/src/main/java/com/aisip/OnO/backend/service/FileUploadService.java
@@ -16,6 +16,7 @@ public interface FileUploadService {
 
     String saveAndGetProcessImageUrl(ImageProcessRegisterDto imageProcessRegisterDto, Problem problem, ImageType imageType);
 
+    void saveImageData(String imageUrl, Problem problem, ImageType imageType);
 
     String getProblemAnalysis(String problemImageUrl);
 

--- a/src/main/java/com/aisip/OnO/backend/service/FileUploadServiceImpl.java
+++ b/src/main/java/com/aisip/OnO/backend/service/FileUploadServiceImpl.java
@@ -56,15 +56,18 @@ public class FileUploadServiceImpl implements FileUploadService {
         return fileUrl;
     }
 
-    private void saveImageData(String imageUrl, Problem problem, ImageType imageType) {
+    @Override
+    public void saveImageData(String imageUrl, Problem problem, ImageType imageType) {
 
-        ImageData imageData = ImageData.builder()
-                .imageUrl(imageUrl)
-                .problem(problem)
-                .imageType(imageType)
-                .build();
+        if(imageDataRepository.findByImageUrl(imageUrl).isEmpty()){
+            ImageData imageData = ImageData.builder()
+                    .imageUrl(imageUrl)
+                    .problem(problem)
+                    .imageType(imageType)
+                    .build();
 
-        imageDataRepository.save(imageData);
+            imageDataRepository.save(imageData);
+        }
     }
 
     @Override

--- a/src/main/java/com/aisip/OnO/backend/service/ProblemService.java
+++ b/src/main/java/com/aisip/OnO/backend/service/ProblemService.java
@@ -4,6 +4,7 @@ import com.aisip.OnO.backend.Dto.Problem.ProblemRegisterDto;
 import com.aisip.OnO.backend.Dto.Problem.ProblemRegisterDtoV2;
 import com.aisip.OnO.backend.Dto.Problem.ProblemResponseDto;
 import com.aisip.OnO.backend.entity.Problem.Problem;
+import com.aisip.OnO.backend.entity.Problem.ProblemRepeat;
 
 import java.util.List;
 
@@ -26,4 +27,8 @@ public interface ProblemService {
     void deleteProblem(Long userId, Long problemId);
 
     void deleteUserProblems(Long userId);
+
+    List<ProblemRepeat> getProblemRepeats(Long problemId);
+
+    void addRepeatCount(Long problemId);
 }

--- a/src/main/java/com/aisip/OnO/backend/service/ProblemService.java
+++ b/src/main/java/com/aisip/OnO/backend/service/ProblemService.java
@@ -1,6 +1,7 @@
 package com.aisip.OnO.backend.service;
 
 import com.aisip.OnO.backend.Dto.Problem.ProblemRegisterDto;
+import com.aisip.OnO.backend.Dto.Problem.ProblemRegisterDtoV2;
 import com.aisip.OnO.backend.Dto.Problem.ProblemResponseDto;
 import com.aisip.OnO.backend.entity.Problem.Problem;
 
@@ -17,6 +18,8 @@ public interface ProblemService {
     Problem createProblem(Long userId);
 
     boolean saveProblem(Long userId, ProblemRegisterDto problemRegisterDto);
+
+    boolean saveProblemV2(Long userId, ProblemRegisterDtoV2 problemRegisterDto);
 
     boolean updateProblem(Long userId, ProblemRegisterDto problemRegisterDto);
 


### PR DESCRIPTION
#### 1. 문제 분석 기능 추가
- FastApi 서버에서 문제 분석 요청 및 결과를 받아오도록 수정했습니다.
- 이미지 보정 및 분석 요청을 분리했습니다. (기존 : 문제 등록 시 이미지 보정 요청)

#### 2. 템플릿 기능 추가
- 템플릿 기능 추가에 따라 템플릿을 구분하는 TemplateType 구조체 값을 Problem 엔티티에 추가했습니다.

#### 3. 문제 복습 기능 추가
- 문제 복습 기능 추가에 따라 사용자의 문제 복습 기록을 담는 ProblemRepeatRepository를 추가했습니다.